### PR TITLE
Humanlayer support in Smallchain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 ts/chains.db
+kubechain/config/secretskubechain/config/secrets/

--- a/kubechain/api/v1alpha1/taskruntoolcall_types.go
+++ b/kubechain/api/v1alpha1/taskruntoolcall_types.go
@@ -7,15 +7,12 @@ import (
 // TaskRunToolCallSpec defines the desired state of TaskRunToolCall
 type TaskRunToolCallSpec struct {
 	// TaskRunRef references the parent TaskRun
-	// +kubebuilder:validation:Required
 	TaskRunRef LocalObjectReference `json:"taskRunRef"`
 
 	// ToolRef references the tool to execute
-	// +kubebuilder:validation:Required
 	ToolRef LocalObjectReference `json:"toolRef"`
 
 	// Arguments contains the arguments for the tool call
-	// +kubebuilder:validation:Required
 	Arguments string `json:"arguments"`
 }
 

--- a/kubechain/api/v1alpha1/tool_types.go
+++ b/kubechain/api/v1alpha1/tool_types.go
@@ -7,10 +7,6 @@ import (
 
 // ToolSpec defines the desired state of Tool
 type ToolSpec struct {
-	// ToolType represents the type of tool; e.g. "function", "delegateToAgent", etc.
-	// +kubebuilder:validation:Enum=function;delegateToAgent
-	ToolType string `json:"toolType,omitempty"`
-
 	// Name is used for inline/function tools (optional if the object name is used).
 	Name string `json:"name,omitempty"`
 
@@ -19,8 +15,15 @@ type ToolSpec struct {
 
 	// Parameters defines the JSON schema for the tool's parameters.
 	// +kubebuilder:pruning:PreserveUnknownFields
-	// +kubebuilder:validation:Type=object
 	Parameters runtime.RawExtension `json:"parameters,omitempty"`
+
+	// Arguments defines the JSON schema for the tool's arguments.
+	// +kubebuilder:pruning:PreserveUnknownFields
+	Arguments runtime.RawExtension `json:"arguments,omitempty"`
+
+	// ToolType represents the type of tool; e.g. "function", "delegateToAgent", "externalAPI" etc.
+	// +kubebuilder:validation:Enum=function;delegateToAgent;externalAPI
+	ToolType string `json:"toolType,omitempty"`
 
 	// Execute defines how the tool should be executed.
 	Execute ToolExecute `json:"execute,omitempty"`
@@ -29,17 +32,23 @@ type ToolSpec struct {
 	AgentRef *AgentReference `json:"agentRef,omitempty"`
 }
 
-// AgentReference defines a reference to an agent resource.
-type AgentReference struct {
-	Name string `json:"name,omitempty"`
-}
-
-// ToolExecute defines execution details for the tool.
 type ToolExecute struct {
 	// Builtin represents an inline (builtin) tool.
 	Builtin *BuiltinToolSpec `json:"builtin,omitempty"`
 
-	// Future fields such as container or remote execution can be added here.
+	// ExternalAPI represents an external API call
+	ExternalAPI *ExternalAPISpec `json:"externalAPI,omitempty"`
+}
+
+// NameReference contains a name reference to another resource
+type NameReference struct {
+	// Name of the referent
+	Name string `json:"name"`
+}
+
+// AgentReference defines a reference to an agent resource.
+type AgentReference struct {
+	Name string `json:"name"`
 }
 
 // BuiltinToolSpec defines the parameters for executing a builtin tool.
@@ -47,6 +56,28 @@ type BuiltinToolSpec struct {
 	// Name is the identifier of the builtin function to run. Today, supports simple math operations
 	// +kubebuilder:validation:Enum=add;subtract;multiply;divide
 	Name string `json:"name,omitempty"`
+}
+
+type ExternalAPISpec struct {
+	// URL for the API endpoint
+	URL string `json:"url,omitempty"`
+
+	// Method specifies the HTTP method to use (GET, POST, etc.)
+	Method string `json:"method,omitempty"`
+
+	// RequiresApproval indicates if this API call needs explicit approval
+	RequiresApproval bool `json:"requiresApproval,omitempty"`
+
+	// Credentials reference for API authentication
+	CredentialsFrom *SecretKeyRef `json:"credentialsFrom,omitempty"`
+}
+
+type SecretKeySelector struct {
+	// Name of the secret
+	Name string `json:"name"`
+
+	// Key within the secret
+	Key string `json:"key"`
 }
 
 // ToolStatus defines the observed state of Tool

--- a/kubechain/config/samples/humanlayer/agent.yaml
+++ b/kubechain/config/samples/humanlayer/agent.yaml
@@ -1,0 +1,22 @@
+apiVersion: kubechain.humanlayer.dev/v1alpha1
+kind: Agent
+metadata:
+  name: humanlayer-agent
+spec:
+  llmRef:
+    name: gpt-4o
+  tools:
+    - name: humanlayer-function-call
+    - name: add
+  system: |
+    You are a calculator agent that can perform mathematical operations.
+    You have access to the 2 tools: 'add' - which adds two numbers together, and 'humanlayer-function-call' which is used for human-in-the-loop approval.
+    You should decide when to use which. Always confirm decisions by using the 'humanlayer-function-call'
+    You should never infer your own reasoning but call the appropriate functions. When you have a response from the humanlayer function return the final result in a succint manner.
+status:
+  ready: true
+  status: "Ready"
+  statusDetail: "Agent is configured and ready"
+
+
+  "TaskRunToolCall.kubechain.humanlayer.dev \"test-taskrun-toolcall-01\" is invalid: [metadata.ownerReferences.apiVersion: Invalid value: \"\": version must not be empty, metadata.ownerReferences.kind: Invalid value: \"\": kind must not be empty]"

--- a/kubechain/config/samples/humanlayer/slack-approval-tool.yaml
+++ b/kubechain/config/samples/humanlayer/slack-approval-tool.yaml
@@ -1,0 +1,36 @@
+apiVersion: kubechain.humanlayer.dev/v1alpha1
+kind: Tool
+metadata:
+  name: humanlayer-function-call
+spec:
+  toolType: externalAPI
+  name: humanlayer-function-call
+  description: Execute a function call via the Humanlayer API
+  parameters:
+    type: object
+    properties:
+      run_id:
+        type: string
+        description: Unique identifier for this run
+      fn:
+        type: string
+        description: The name of the function to call
+      kwargs:
+        type: object
+        description: The arguments to pass to the function
+    required:
+      - run_id
+      - fn
+      - kwargs
+  execute:
+    externalAPI:
+      url: "https://api.humanlayer.dev/humanlayer/v1/function_calls"
+      method: "POST"
+      requiresApproval: true
+      credentialsFrom:
+        name: humanlayer-api-credentials
+        key: api-key
+status:
+  ready: true
+  status: "Ready"
+  statusDetail: "Tool is configured and ready to use"

--- a/kubechain/config/samples/humanlayer/slack-task.yaml
+++ b/kubechain/config/samples/humanlayer/slack-task.yaml
@@ -1,0 +1,8 @@
+apiVersion: kubechain.humanlayer.dev/v1alpha1
+kind: Task
+metadata:
+  name: approve-summation
+spec:
+  agentRef:
+    name: humanlayer-agent
+  message: "What is 25 + 17?"

--- a/kubechain/config/samples/humanlayer/slack-taskrun.yaml
+++ b/kubechain/config/samples/humanlayer/slack-taskrun.yaml
@@ -1,0 +1,7 @@
+apiVersion: kubechain.humanlayer.dev/v1alpha1
+kind: TaskRun
+metadata:
+  name: pizdarija
+spec:
+  taskRef:
+    name: approve-summation

--- a/kubechain/internal/controller/agent/agent_controller.go
+++ b/kubechain/internal/controller/agent/agent_controller.go
@@ -1,4 +1,4 @@
-package controller
+package agent
 
 import (
 	"context"

--- a/kubechain/internal/controller/agent/agent_controller_test.go
+++ b/kubechain/internal/controller/agent/agent_controller_test.go
@@ -1,4 +1,4 @@
-package controller
+package agent
 
 import (
 	"context"

--- a/kubechain/internal/controller/agent/suite_test.go
+++ b/kubechain/internal/controller/agent/suite_test.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	kubechainv1alpha1 "github.com/humanlayer/smallchain/kubechain/api/v1alpha1"
+)
+
+var (
+	ctx       context.Context
+	cancel    context.CancelFunc
+	testEnv   *envtest.Environment
+	cfg       *rest.Config
+	k8sClient client.Client
+)
+
+func TestControllers(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Controller Suite")
+}
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+	ctx, cancel = context.WithCancel(context.TODO())
+
+	By("bootstrapping test environment")
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: true,
+		BinaryAssetsDirectory: filepath.Join("..", "..", "bin", "k8s", "1.32.0-darwin-arm64"),
+	}
+
+	var err error
+	cfg, err = testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
+
+	err = kubechainv1alpha1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(k8sClient).NotTo(BeNil())
+})
+
+var _ = AfterSuite(func() {
+	By("tearing down the test environment")
+	cancel()
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
+})

--- a/kubechain/internal/controller/llm/llm_controller.go
+++ b/kubechain/internal/controller/llm/llm_controller.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controller
+package llm
 
 import (
 	"context"

--- a/kubechain/internal/controller/llm/llm_controller_test.go
+++ b/kubechain/internal/controller/llm/llm_controller_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controller
+package llm
 
 import (
 	"context"

--- a/kubechain/internal/controller/llm/suite_test.go
+++ b/kubechain/internal/controller/llm/suite_test.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package llm
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	kubechainv1alpha1 "github.com/humanlayer/smallchain/kubechain/api/v1alpha1"
+)
+
+var (
+	ctx       context.Context
+	cancel    context.CancelFunc
+	testEnv   *envtest.Environment
+	cfg       *rest.Config
+	k8sClient client.Client
+)
+
+func TestControllers(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Controller Suite")
+}
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+	ctx, cancel = context.WithCancel(context.TODO())
+
+	By("bootstrapping test environment")
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: true,
+		BinaryAssetsDirectory: filepath.Join("..", "..", "bin", "k8s", "1.32.0-darwin-arm64"),
+	}
+
+	var err error
+	cfg, err = testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
+
+	err = kubechainv1alpha1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(k8sClient).NotTo(BeNil())
+})
+
+var _ = AfterSuite(func() {
+	By("tearing down the test environment")
+	cancel()
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
+})

--- a/kubechain/internal/controller/task/suite_test.go
+++ b/kubechain/internal/controller/task/suite_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controller
+package task
 
 import (
 	"context"
@@ -56,6 +56,7 @@ var _ = BeforeSuite(func() {
 	testEnv = &envtest.Environment{
 		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "config", "crd", "bases")},
 		ErrorIfCRDPathMissing: true,
+		BinaryAssetsDirectory: filepath.Join("..", "..", "bin", "k8s", "1.32.0-darwin-arm64"),
 	}
 
 	var err error

--- a/kubechain/internal/controller/task/task_controller.go
+++ b/kubechain/internal/controller/task/task_controller.go
@@ -1,4 +1,4 @@
-package controller
+package task
 
 import (
 	"context"

--- a/kubechain/internal/controller/task/task_controller_test.go
+++ b/kubechain/internal/controller/task/task_controller_test.go
@@ -1,4 +1,4 @@
-package controller
+package task
 
 import (
 	"context"

--- a/kubechain/internal/controller/taskrun/suite_test.go
+++ b/kubechain/internal/controller/taskrun/suite_test.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package taskrun
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	kubechainv1alpha1 "github.com/humanlayer/smallchain/kubechain/api/v1alpha1"
+)
+
+var (
+	ctx       context.Context
+	cancel    context.CancelFunc
+	testEnv   *envtest.Environment
+	cfg       *rest.Config
+	k8sClient client.Client
+)
+
+func TestControllers(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Controller Suite")
+}
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+	ctx, cancel = context.WithCancel(context.TODO())
+
+	By("bootstrapping test environment")
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: true,
+		BinaryAssetsDirectory: filepath.Join("..", "..", "bin", "k8s", "1.32.0-darwin-arm64"),
+	}
+
+	var err error
+	cfg, err = testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
+
+	err = kubechainv1alpha1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(k8sClient).NotTo(BeNil())
+})
+
+var _ = AfterSuite(func() {
+	By("tearing down the test environment")
+	cancel()
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
+})

--- a/kubechain/internal/controller/taskrun_controller.go
+++ b/kubechain/internal/controller/taskrun_controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -42,7 +43,7 @@ func (r *TaskRunReconciler) getTask(ctx context.Context, taskRun *kubechainv1alp
 	}
 
 	if !task.Status.Ready {
-		return task, nil // Return task but indicate it's not ready
+		return nil, fmt.Errorf("task %q is not ready", task.Name)
 	}
 
 	return task, nil
@@ -51,13 +52,20 @@ func (r *TaskRunReconciler) getTask(ctx context.Context, taskRun *kubechainv1alp
 // Reconcile validates the taskrun's task reference and sends the prompt to the LLM.
 func (r *TaskRunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
+	logger.Info("Starting TaskRunToolCall reconciliation", "request", req)
 
 	var taskRun kubechainv1alpha1.TaskRun
 	if err := r.Get(ctx, req.NamespacedName, &taskRun); err != nil {
+		logger.Error(err, "Failed to get TaskRun")
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
 	logger.Info("Starting reconciliation", "name", taskRun.Name)
+	logger.Info("Processing TaskRun",
+		"phase", taskRun.Status.Phase,
+		"status", taskRun.Status.Status,
+		"taskRef", taskRun.Spec.TaskRef.Name,
+	)
 
 	// Create a copy for status update
 	statusUpdate := taskRun.DeepCopy()
@@ -150,6 +158,65 @@ func (r *TaskRunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			return ctrl.Result{}, err
 		}
 		return ctrl.Result{Requeue: true}, nil
+	}
+
+	// Handle the ToolCallsPending phase
+	if taskRun.Status.Phase == kubechainv1alpha1.TaskRunPhaseToolCallsPending {
+		// List all tool calls owned by this TaskRun
+		var toolCalls kubechainv1alpha1.TaskRunToolCallList
+		if err := r.List(ctx, &toolCalls,
+			client.InNamespace(req.Namespace),
+			client.MatchingFields{"spec.taskRunRef.name": taskRun.Name},
+		); err != nil {
+			logger.Error(err, "Failed to list TaskRunToolCalls")
+			return ctrl.Result{}, err
+		}
+
+		allCompleted := true
+		for _, tc := range toolCalls.Items {
+			if tc.Status.Phase != kubechainv1alpha1.TaskRunToolCallPhaseSucceeded {
+				allCompleted = false
+				break
+			}
+		}
+
+		if allCompleted {
+			// Append tool call results to task message
+			var toolResults strings.Builder
+			toolResults.WriteString("\nThe following tool calls have been executed:\n")
+			for _, tc := range toolCalls.Items {
+				toolResults.WriteString(fmt.Sprintf("- Tool: %s, Result: %s\n", tc.Spec.ToolRef.Name, tc.Status.Result))
+			}
+			task.Spec.Message += toolResults.String()
+
+			// Update context window
+			statusUpdate.Status.ContextWindow = append(statusUpdate.Status.ContextWindow, kubechainv1alpha1.Message{
+				Role:    "user",
+				Content: toolResults.String(),
+			})
+
+			// Transition to ReadyForLLM
+			statusUpdate.Status.Phase = kubechainv1alpha1.TaskRunPhaseReadyForLLM
+			statusUpdate.Status.Status = "Ready"
+			statusUpdate.Status.StatusDetail = "All tool calls completed"
+
+			if err := r.Status().Update(ctx, statusUpdate); err != nil {
+				logger.Error(err, "Failed to update TaskRun status")
+				return ctrl.Result{}, err
+			}
+
+			logger.Info("Updating Task message", "task", task.Name, "message", task.Spec.Message)
+			if err := r.Update(ctx, task); err != nil {
+				logger.Error(err, "Failed to update Task message")
+				return ctrl.Result{}, err
+			}
+
+			return ctrl.Result{}, nil
+		}
+
+		// Tool calls are still pending
+		logger.Info("Tool calls pending, requeueing TaskRun", "taskrun", taskRun.Name, "requeueAfter", time.Second*5)
+		return ctrl.Result{RequeueAfter: time.Second * 5}, nil
 	}
 
 	// Only proceed with LLM request if we're in ReadyForLLM phase
@@ -259,7 +326,20 @@ func (r *TaskRunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		tools = append(tools, toolParam)
 	}
 
-	// Send the prompt to the LLM using the OpenAI client.
+	// Send the prompt to the LLM using the OpenAI client
+
+	// Before the SendRequest call
+	logger.Info("Sending LLM request",
+		"taskrun", taskRun.Name,
+		"systemPrompt", agent.Spec.System,
+		"userMessage", task.Spec.Message,
+		"toolCount", len(tools))
+
+	for i, tool := range tools {
+		logger.Info("Tool being sent to LLM",
+			"index", i,
+			"name", *&tool.Type)
+	}
 	output, err := llmClient.SendRequest(ctx, agent.Spec.System, task.Spec.Message, tools)
 	if err != nil {
 		logger.Error(err, "LLM request failed")
@@ -275,8 +355,32 @@ func (r *TaskRunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return ctrl.Result{}, err
 	}
 
+	logger.Info("LLM response received",
+		"taskrun", taskRun.Name,
+		"hasContent", output.Content != "",
+		"toolCallCount", len(output.ToolCalls))
+
+	for i, tc := range output.ToolCalls {
+		logger.Info("Tool call from LLM",
+			"index", i,
+			"name", tc.Function.Name,
+			"arguments", tc.Function.Arguments)
+	}
+	logger.Info("LLM call completed", "taskrun", taskRun.Name, "output", output)
+
+	// Check if we need to restore the original message (if we added tool results)
+	if strings.Contains(task.Spec.Message, "The following tool calls have been executed") {
+		// Extract the original message (what comes before the tool results)
+		originalMessage := strings.Split(task.Spec.Message, "The following tool calls have been executed")[0]
+		task.Spec.Message = strings.TrimSpace(originalMessage)
+		if err := r.Update(ctx, task); err != nil {
+			logger.Error(err, "Failed to restore original task message")
+			// Continue processing even if this fails
+		}
+	}
+
 	if output.Content != "" {
-		// final answer branch
+		// Final answer branch
 		statusUpdate.Status.Output = output.Content
 		statusUpdate.Status.Phase = kubechainv1alpha1.TaskRunPhaseFinalAnswer
 		statusUpdate.Status.Ready = true
@@ -288,8 +392,8 @@ func (r *TaskRunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		statusUpdate.Status.StatusDetail = "LLM final response received"
 		statusUpdate.Status.Error = ""
 		r.recorder.Event(&taskRun, corev1.EventTypeNormal, "LLMFinalAnswer", "LLM response received successfully")
-	} else {
-		// tool call branch: create TaskRunToolCall objects for each tool call returned by the LLM.
+	} else if len(output.ToolCalls) > 0 {
+		// Tool call branch: create TaskRunToolCall objects for each tool call returned by the LLM
 		statusUpdate.Status.Output = ""
 		statusUpdate.Status.Phase = kubechainv1alpha1.TaskRunPhaseToolCallsPending
 		statusUpdate.Status.ContextWindow = append(statusUpdate.Status.ContextWindow, kubechainv1alpha1.Message{
@@ -301,49 +405,79 @@ func (r *TaskRunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		statusUpdate.Status.StatusDetail = "LLM response received, tool calls pending"
 		statusUpdate.Status.Error = ""
 
-		// Update the parent's status before creating tool call objects.
+		logger.Info("Updating TaskRun status", "taskrun", taskRun.Name, "status", statusUpdate.Status)
+
+		// Update the parent's status before creating tool call objects
 		if err := r.Status().Update(ctx, statusUpdate); err != nil {
 			logger.Error(err, "Unable to update TaskRun status")
 			return ctrl.Result{}, err
 		}
 
-		// For each tool call, create a new TaskRunToolCall.
-		// Using the parent's details from statusUpdate.
+		// For each tool call, create a new TaskRunToolCall
 		for i, tc := range output.ToolCalls {
 			newName := fmt.Sprintf("%s-toolcall-%02d", statusUpdate.Name, i+1)
-			newTRTC := &kubechainv1alpha1.TaskRunToolCall{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      newName,
-					Namespace: statusUpdate.Namespace,
-					OwnerReferences: []metav1.OwnerReference{
-						{
-							APIVersion: statusUpdate.APIVersion,
-							Kind:       statusUpdate.Kind, // Should be "TaskRun"
-							Name:       statusUpdate.Name,
-							UID:        statusUpdate.UID,
-							Controller: pointer.BoolPtr(true),
+
+			// Check if a TaskRunToolCall with this name already exists
+			existingTRTC := &kubechainv1alpha1.TaskRunToolCall{}
+			err := r.Get(ctx, client.ObjectKey{Namespace: statusUpdate.Namespace, Name: newName}, existingTRTC)
+
+			logger.Info("Tool call arguments", "functionArguments", tc.Function.Arguments)
+			// Only create if it doesn't exist
+			if err != nil && client.IgnoreNotFound(err) == nil {
+				// Create new TaskRunToolCall
+				newTRTC := &kubechainv1alpha1.TaskRunToolCall{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      newName,
+						Namespace: statusUpdate.Namespace,
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion: statusUpdate.APIVersion,
+								Kind:       statusUpdate.Kind,
+								Name:       statusUpdate.Name,
+								UID:        statusUpdate.UID,
+								Controller: pointer.BoolPtr(true),
+							},
 						},
 					},
-				},
-				Spec: kubechainv1alpha1.TaskRunToolCallSpec{
-					TaskRunRef: kubechainv1alpha1.LocalObjectReference{
-						Name: statusUpdate.Name,
+					Spec: kubechainv1alpha1.TaskRunToolCallSpec{
+						TaskRunRef: kubechainv1alpha1.LocalObjectReference{
+							Name: statusUpdate.Name,
+						},
+						ToolRef: kubechainv1alpha1.LocalObjectReference{
+							Name: tc.Function.Name,
+						},
+						Arguments: tc.Function.Arguments,
 					},
-					ToolRef: kubechainv1alpha1.LocalObjectReference{
-						Name: tc.Function.Name,
-					},
-					Arguments: tc.Function.Arguments,
-				},
-			}
-			if err := r.Client.Create(ctx, newTRTC); err != nil {
-				logger.Error(err, "Failed to create TaskRunToolCall", "name", newName)
+				}
+				if err := r.Client.Create(ctx, newTRTC); err != nil {
+					logger.Error(err, "Failed to create TaskRunToolCall", "name", newName)
+					return ctrl.Result{}, err
+				}
+				logger.Info("Creating TaskRunToolCall", "name", newName, "toolCall", newTRTC)
+				r.recorder.Event(&taskRun, corev1.EventTypeNormal, "ToolCallCreated", "Created TaskRunToolCall "+newName)
+			} else if err == nil {
+				// Already exists, log and continue
+				logger.Info("TaskRunToolCall already exists", "name", newName, "phase", existingTRTC.Status.Phase)
+			} else {
+				// Handle other errors
+				logger.Error(err, "Error checking if TaskRunToolCall exists", "name", newName)
 				return ctrl.Result{}, err
 			}
 			logger.Info("Created TaskRunToolCall", "name", newName)
 			r.recorder.Event(&taskRun, corev1.EventTypeNormal, "ToolCallCreated", "Created TaskRunToolCall "+newName)
 		}
+	} else {
+		// Handle the case where no content and no tool calls were returned
+		err := fmt.Errorf("LLM response contained neither content nor tool calls")
+		logger.Error(err, "Invalid LLM response")
+		statusUpdate.Status.Ready = false
+		statusUpdate.Status.Status = "Error"
+		statusUpdate.Status.StatusDetail = err.Error()
+		statusUpdate.Status.Error = err.Error()
+		r.recorder.Event(&taskRun, corev1.EventTypeWarning, "InvalidLLMResponse", err.Error())
 	}
-	// Update status for either branch.
+
+	// Update status for any branch
 	if err := r.Status().Update(ctx, statusUpdate); err != nil {
 		logger.Error(err, "Unable to update TaskRun status")
 		return ctrl.Result{}, err
@@ -362,6 +496,17 @@ func (r *TaskRunReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	if r.newLLMClient == nil {
 		r.newLLMClient = llmclient.NewOpenAIClient
 	}
+
+	// Add this index for looking up TaskRunToolCalls by parent TaskRun
+	if err := mgr.GetFieldIndexer().IndexField(context.Background(),
+		&kubechainv1alpha1.TaskRunToolCall{},
+		"spec.taskRunRef.name",
+		func(o client.Object) []string {
+			return []string{o.(*kubechainv1alpha1.TaskRunToolCall).Spec.TaskRunRef.Name}
+		}); err != nil {
+		return err
+	}
+
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&kubechainv1alpha1.TaskRun{}).
 		Complete(r)

--- a/kubechain/internal/controller/taskruntoolcall/suite_test.go
+++ b/kubechain/internal/controller/taskruntoolcall/suite_test.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package taskruntoolcall
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	kubechainv1alpha1 "github.com/humanlayer/smallchain/kubechain/api/v1alpha1"
+)
+
+var (
+	ctx       context.Context
+	cancel    context.CancelFunc
+	testEnv   *envtest.Environment
+	cfg       *rest.Config
+	k8sClient client.Client
+)
+
+func TestControllers(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Controller Suite")
+}
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+	ctx, cancel = context.WithCancel(context.TODO())
+
+	By("bootstrapping test environment")
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: true,
+		BinaryAssetsDirectory: filepath.Join("..", "..", "bin", "k8s", "1.32.0-darwin-arm64"),
+	}
+
+	var err error
+	cfg, err = testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
+
+	err = kubechainv1alpha1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(k8sClient).NotTo(BeNil())
+})
+
+var _ = AfterSuite(func() {
+	By("tearing down the test environment")
+	cancel()
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
+})

--- a/kubechain/internal/controller/taskruntoolcall/taskruntoolcall_controller_test.go
+++ b/kubechain/internal/controller/taskruntoolcall/taskruntoolcall_controller_test.go
@@ -1,4 +1,4 @@
-package controller
+package taskruntoolcall
 
 import (
 	"context"

--- a/kubechain/internal/controller/taskruntoolcall_controller.go
+++ b/kubechain/internal/controller/taskruntoolcall_controller.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"strconv"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -14,7 +16,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
+	"github.com/google/uuid"
 	kubechainv1alpha1 "github.com/humanlayer/smallchain/kubechain/api/v1alpha1"
+	externalapi "github.com/humanlayer/smallchain/kubechain/internal/externalAPI"
+	"github.com/humanlayer/smallchain/kubechain/internal/humanlayer"
 )
 
 // TaskRunToolCallReconciler reconciles a TaskRunToolCall object.
@@ -22,6 +27,90 @@ type TaskRunToolCallReconciler struct {
 	client.Client
 	Scheme   *runtime.Scheme
 	recorder record.EventRecorder
+	server   *http.Server
+}
+
+func (r *TaskRunToolCallReconciler) webhookHandler(w http.ResponseWriter, req *http.Request) {
+	logger := log.FromContext(context.Background())
+	var webhook humanlayer.FunctionCall
+	if err := json.NewDecoder(req.Body).Decode(&webhook); err != nil {
+		logger.Error(err, "Failed to decode webhook payload")
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	logger.Info("Received webhook", "webhook", webhook)
+
+	if webhook.Status != nil && webhook.Status.Approved != nil {
+		if *webhook.Status.Approved {
+			logger.Info("Email approved", "comment", webhook.Status.Comment)
+		} else {
+			logger.Info("Email request denied")
+		}
+
+		// Update TaskRunToolCall status
+		if err := r.updateTaskRunToolCall(context.Background(), webhook); err != nil {
+			logger.Error(err, "Failed to update TaskRunToolCall status")
+			http.Error(w, "Failed to update status", http.StatusInternalServerError)
+			return
+		}
+	}
+
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte(`{"status": "ok"}`))
+}
+
+func (r *TaskRunToolCallReconciler) updateTaskRunToolCall(ctx context.Context, webhook humanlayer.FunctionCall) error {
+	logger := log.FromContext(ctx)
+	var trtc kubechainv1alpha1.TaskRunToolCall
+
+	if err := r.Get(ctx, client.ObjectKey{Namespace: "default", Name: webhook.RunID}, &trtc); err != nil {
+		return fmt.Errorf("failed to get TaskRunToolCall: %w", err)
+	}
+
+	if webhook.Status != nil && webhook.Status.Approved != nil {
+		// Update the TaskRunToolCall status with the webhook data
+		if *webhook.Status.Approved {
+			trtc.Status.Result = fmt.Sprintf("Approved: %s", *webhook.Status.Comment)
+			trtc.Status.Phase = kubechainv1alpha1.TaskRunToolCallPhaseSucceeded
+			trtc.Status.Status = "Ready"
+			trtc.Status.StatusDetail = "Tool executed successfully"
+		} else {
+			trtc.Status.Result = "Rejected"
+			trtc.Status.Phase = kubechainv1alpha1.TaskRunToolCallPhaseFailed
+			trtc.Status.Status = "Error"
+			trtc.Status.StatusDetail = "Tool execution rejected"
+		}
+
+		// if webhook.Status.RespondedAt != nil {
+		// 		trtc.Status.RespondedAt = &metav1.Time{Time: *webhook.Status.RespondedAt}
+		// }
+
+		// if webhook.Status.Approved != nil {
+		// 		trtc.Status.Approved = webhook.Status.Approved
+		// }
+
+		if err := r.Status().Update(ctx, &trtc); err != nil {
+			return fmt.Errorf("failed to update TaskRunToolCall status: %w", err)
+		}
+		logger.Info("TaskRunToolCall status updated", "name", trtc.Name, "phase", trtc.Status.Phase)
+	}
+
+	return nil
+}
+
+// Helper function to convert various value types to float64
+func convertToFloat(val interface{}) (float64, error) {
+	switch v := val.(type) {
+	case float64:
+		return v, nil
+	case int:
+		return float64(v), nil
+	case string:
+		return strconv.ParseFloat(v, 64)
+	default:
+		return 0, fmt.Errorf("cannot convert %T to float64", val)
+	}
 }
 
 // Reconcile processes TaskRunToolCall objects.
@@ -44,8 +133,12 @@ func (r *TaskRunToolCallReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 			logger.Error(err, "Failed to update initial status on TaskRunToolCall")
 			return ctrl.Result{}, err
 		}
-		// Requeue so we pick up the updated status.
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{}, nil
+	}
+
+	if trtc.Status.Phase == kubechainv1alpha1.TaskRunToolCallPhaseSucceeded || trtc.Status.Phase == kubechainv1alpha1.TaskRunToolCallPhaseFailed {
+		logger.Info("TaskRunToolCall already completed, nothing to do", "phase", trtc.Status.Phase)
+		return ctrl.Result{}, nil
 	}
 
 	// Check if a child TaskRun already exists for this tool call.
@@ -75,10 +168,32 @@ func (r *TaskRunToolCallReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return ctrl.Result{}, err
 	}
 
-	// --- New direct execution logic ---
-	// For now, support only direct execution.
-	// If the tool is of type "delegateToAgent", return an error.
-	if tool.Spec.ToolType == "delegateToAgent" {
+	// Determine tool type from the Tool resource
+	var toolType string
+	if tool.Spec.Execute.Builtin != nil {
+		toolType = "function"
+	} else if tool.Spec.AgentRef != nil {
+		toolType = "delegateToAgent"
+	} else if tool.Spec.Execute.ExternalAPI != nil {
+		toolType = "externalAPI"
+	} else if tool.Spec.ToolType != "" {
+		toolType = tool.Spec.ToolType
+	} else {
+		err := fmt.Errorf("unknown tool type: tool doesn't have valid execution configuration")
+		logger.Error(err, "Invalid tool configuration")
+		trtc.Status.Status = "Error"
+		trtc.Status.StatusDetail = err.Error()
+		trtc.Status.Error = err.Error()
+		r.recorder.Event(&trtc, corev1.EventTypeWarning, "ValidationFailed", err.Error())
+		if err := r.Status().Update(ctx, &trtc); err != nil {
+			logger.Error(err, "Failed to update status")
+			return ctrl.Result{}, err
+		}
+		return ctrl.Result{}, err
+	}
+
+	// Handle different tool types based on determined type
+	if toolType == "delegateToAgent" {
 		err := fmt.Errorf("delegation is not implemented yet; only direct execution is supported")
 		logger.Error(err, "Delegation not implemented")
 		trtc.Status.Status = "Error"
@@ -90,13 +205,13 @@ func (r *TaskRunToolCallReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 			return ctrl.Result{}, err
 		}
 		return ctrl.Result{}, err
-	} else if tool.Spec.ToolType == "function" {
-		// Execute built-in function directly.
+	} else if toolType == "function" {
+		// Parse the arguments string as JSON
 		var args map[string]float64
 		if err := json.Unmarshal([]byte(trtc.Spec.Arguments), &args); err != nil {
-			logger.Error(err, "Failed to parse arguments")
+			logger.Error(err, "Failed to parse arguments as numeric values")
 			trtc.Status.Status = "Error"
-			trtc.Status.StatusDetail = "Invalid arguments JSON"
+			trtc.Status.StatusDetail = "Invalid arguments: expected numeric values"
 			trtc.Status.Error = err.Error()
 			r.recorder.Event(&trtc, corev1.EventTypeWarning, "ExecutionFailed", err.Error())
 			if err := r.Status().Update(ctx, &trtc); err != nil {
@@ -106,16 +221,62 @@ func (r *TaskRunToolCallReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 			return ctrl.Result{}, err
 		}
 
+		logger.Info("Tool call arguments", "toolName", tool.Name, "arguments", args)
+
+		// Try to convert arguments - be more flexible with parameter names and types
+		var a, b float64
+		var err error
+
+		// Check for different possible parameter names and formats
+		if aVal, ok := args["a"]; ok {
+			a, err = convertToFloat(aVal)
+		} else if aVal, ok := args["first"]; ok {
+			a, err = convertToFloat(aVal)
+		} else if aVal, ok := args["num1"]; ok {
+			a, err = convertToFloat(aVal)
+		} else if aVal, ok := args["x"]; ok {
+			a, err = convertToFloat(aVal)
+		} else {
+			err = fmt.Errorf("missing first number parameter")
+		}
+
+		if err != nil {
+			logger.Error(err, "Failed to parse first argument")
+			// Error handling...
+			return ctrl.Result{}, err
+		}
+
+		if bVal, ok := args["b"]; ok {
+			b, err = convertToFloat(bVal)
+		} else if bVal, ok := args["second"]; ok {
+			b, err = convertToFloat(bVal)
+		} else if bVal, ok := args["num2"]; ok {
+			b, err = convertToFloat(bVal)
+		} else if bVal, ok := args["y"]; ok {
+			b, err = convertToFloat(bVal)
+		} else {
+			err = fmt.Errorf("missing second number parameter")
+		}
+
+		if err != nil {
+			logger.Error(err, "Failed to parse second argument")
+			// Error handling...
+			return ctrl.Result{}, err
+		}
+
+		// Execute the appropriate function
+		functionName := tool.Spec.Execute.Builtin.Name
 		var res float64
-		switch tool.Spec.Execute.Builtin.Name {
+
+		switch functionName {
 		case "add":
-			res = args["a"] + args["b"]
+			res = a + b
 		case "subtract":
-			res = args["a"] - args["b"]
+			res = a - b
 		case "multiply":
-			res = args["a"] * args["b"]
+			res = a * b
 		case "divide":
-			if args["b"] == 0 {
+			if b == 0 {
 				err := fmt.Errorf("division by zero")
 				logger.Error(err, "Division by zero")
 				trtc.Status.Status = "Error"
@@ -128,9 +289,9 @@ func (r *TaskRunToolCallReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 				}
 				return ctrl.Result{}, err
 			}
-			res = args["a"] / args["b"]
+			res = a / b
 		default:
-			err := fmt.Errorf("unsupported builtin function %q", tool.Spec.Execute.Builtin.Name)
+			err := fmt.Errorf("unsupported builtin function %q", functionName)
 			logger.Error(err, "Unsupported builtin")
 			trtc.Status.Status = "Error"
 			trtc.Status.StatusDetail = err.Error()
@@ -143,7 +304,7 @@ func (r *TaskRunToolCallReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 			return ctrl.Result{}, err
 		}
 
-		// Update TaskRunToolCall status with the function result.
+		// Update TaskRunToolCall status with the function result
 		trtc.Status.Result = fmt.Sprintf("%v", res)
 		trtc.Status.Phase = kubechainv1alpha1.TaskRunToolCallPhaseSucceeded
 		trtc.Status.Status = "Ready"
@@ -155,11 +316,164 @@ func (r *TaskRunToolCallReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		logger.Info("Direct execution completed", "result", res)
 		r.recorder.Event(&trtc, corev1.EventTypeNormal, "ExecutionSucceeded", fmt.Sprintf("Tool %q executed successfully", tool.Name))
 		return ctrl.Result{}, nil
+	} else if toolType == "externalAPI" {
+		if tool.Spec.Execute.ExternalAPI == nil {
+			err := fmt.Errorf("externalAPI tool missing execution details")
+			logger.Error(err, "Missing execution details")
+			trtc.Status.Status = "Error"
+			trtc.Status.StatusDetail = err.Error()
+			trtc.Status.Error = err.Error()
+			r.recorder.Event(&trtc, corev1.EventTypeWarning, "ValidationFailed", err.Error())
+			if err := r.Status().Update(ctx, &trtc); err != nil {
+				logger.Error(err, "Failed to update status")
+				return ctrl.Result{}, err
+			}
+			return ctrl.Result{}, err
+		}
+
+		// Get API key from secret
+		var apiKey string
+		if tool.Spec.Execute.ExternalAPI.CredentialsFrom != nil {
+			var secret corev1.Secret
+			err := r.Get(ctx, client.ObjectKey{
+				Namespace: trtc.Namespace,
+				Name:      tool.Spec.Execute.ExternalAPI.CredentialsFrom.Name,
+			}, &secret)
+			if err != nil {
+				logger.Error(err, "Failed to get API credentials")
+				trtc.Status.Status = "Error"
+				trtc.Status.StatusDetail = fmt.Sprintf("Failed to get API credentials: %v", err)
+				trtc.Status.Error = err.Error()
+				r.recorder.Event(&trtc, corev1.EventTypeWarning, "ValidationFailed", err.Error())
+				if err := r.Status().Update(ctx, &trtc); err != nil {
+					logger.Error(err, "Failed to update status")
+					return ctrl.Result{}, err
+				}
+				return ctrl.Result{}, err
+			}
+
+			apiKey = string(secret.Data[tool.Spec.Execute.ExternalAPI.CredentialsFrom.Key])
+			logger.Info("Retrieved API key", "key", apiKey)
+			if apiKey == "" {
+				err := fmt.Errorf("empty API key in secret")
+				logger.Error(err, "Empty API key")
+				trtc.Status.Status = "Error"
+				trtc.Status.StatusDetail = err.Error()
+				trtc.Status.Error = err.Error()
+				r.recorder.Event(&trtc, corev1.EventTypeWarning, "ValidationFailed", err.Error())
+				if err := r.Status().Update(ctx, &trtc); err != nil {
+					logger.Error(err, "Failed to update status")
+					return ctrl.Result{}, err
+				}
+				return ctrl.Result{}, err
+			}
+		}
+
+		var argsMap map[string]interface{}
+		if err := json.Unmarshal([]byte(trtc.Spec.Arguments), &argsMap); err != nil {
+			logger.Error(err, "Failed to parse arguments")
+			trtc.Status.Status = "Error"
+			trtc.Status.StatusDetail = "Invalid arguments JSON"
+			trtc.Status.Error = err.Error()
+			trtc.Status.Phase = kubechainv1alpha1.TaskRunToolCallPhaseFailed
+			r.recorder.Event(&trtc, corev1.EventTypeWarning, "ExecutionFailed", err.Error())
+			if err := r.Status().Update(ctx, &trtc); err != nil {
+				logger.Error(err, "Failed to update status")
+				return ctrl.Result{}, err
+			}
+			return ctrl.Result{}, err
+		}
+		// And modify it to:
+		if len(argsMap) == 0 && tool.Name == "humanlayer-function-call" {
+			// RegisterClient adds the HumanLayer client to the external API registry
+			humanlayer.RegisterClient()
+
+			// Create kwargs map first to ensure it's properly initialized
+			kwargs := map[string]interface{}{
+				"tool_name": trtc.Spec.ToolRef.Name,
+				"task_run":  trtc.Spec.TaskRunRef.Name,
+				"namespace": trtc.Namespace,
+			}
+
+			// Default function call for HumanLayer with verified kwargs
+			argsMap = map[string]interface{}{
+				"fn":     "approve_tool_call",
+				"kwargs": kwargs,
+			}
+
+			// Log to verify
+			logger.Info("Created humanlayer function call args",
+				"argsMap", argsMap,
+				"kwargs", kwargs)
+		}
+
+		// Get the external client
+		externalClient, err := externalapi.DefaultRegistry.GetClient(
+			tool.Name,
+			r.Client,
+			trtc.Namespace,
+			tool.Spec.Execute.ExternalAPI.CredentialsFrom,
+		)
+		if err != nil {
+			logger.Error(err, "Failed to get external client")
+			trtc.Status.Status = "Error"
+			trtc.Status.StatusDetail = fmt.Sprintf("Failed to get external client: %v", err)
+			trtc.Status.Error = err.Error()
+			trtc.Status.Phase = kubechainv1alpha1.TaskRunToolCallPhaseFailed
+			r.recorder.Event(&trtc, corev1.EventTypeWarning, "ExecutionFailed", err.Error())
+			if err := r.Status().Update(ctx, &trtc); err != nil {
+				logger.Error(err, "Failed to update status")
+				return ctrl.Result{}, err
+			}
+			return ctrl.Result{}, err
+		}
+
+		var fn string
+		var kwargs map[string]interface{}
+
+		// Extract function name
+		if fnVal, fnExists := argsMap["fn"]; fnExists && fnVal != nil {
+			fn, _ = fnVal.(string)
+		}
+
+		// Extract kwargs
+		if kwargsVal, kwargsExists := argsMap["kwargs"]; kwargsExists && kwargsVal != nil {
+			kwargs, _ = kwargsVal.(map[string]interface{})
+		}
+
+		// Generate call ID
+		callID := "call-" + uuid.New().String()
+
+		// Prepare function call spec
+		functionSpec := map[string]interface{}{
+			"fn":     fn,
+			"kwargs": kwargs,
+		}
+
+		// Make the API call
+		result, err := externalClient.Call(ctx, trtc.Name, callID, functionSpec)
+		if err != nil {
+			logger.Error(err, "External API call failed")
+			// Error handling...
+			return ctrl.Result{}, err
+		}
+
+		// Update TaskRunToolCall with the result
+		trtc.Status.Result = string(result)
+		trtc.Status.Phase = kubechainv1alpha1.TaskRunToolCallPhaseSucceeded
+		trtc.Status.Status = "Ready"
+		trtc.Status.StatusDetail = "Tool executed successfully"
+		if err := r.Status().Update(ctx, &trtc); err != nil {
+			logger.Error(err, "Failed to update TaskRunToolCall status")
+			return ctrl.Result{}, err
+		}
+		logger.Info("TaskRunToolCall completed", "phase", trtc.Status.Phase)
+		return ctrl.Result{}, nil
 	}
 
 	// Fallback: if tool type is not recognized.
-	err := fmt.Errorf("unsupported tool type %q", tool.Spec.ToolType)
-	logger.Error(err, "Unsupported tool type")
+	err := fmt.Errorf("unsupported tool configuration")
+	logger.Error(err, "Unsupported tool configuration")
 	trtc.Status.Status = "Error"
 	trtc.Status.StatusDetail = err.Error()
 	trtc.Status.Error = err.Error()
@@ -171,10 +485,27 @@ func (r *TaskRunToolCallReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	return ctrl.Result{}, err
 }
 
-// SetupWithManager sets up this controller with the Manager.
 func (r *TaskRunToolCallReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	r.recorder = mgr.GetEventRecorderFor("taskruntoolcall-controller")
+	r.server = &http.Server{Addr: ":8080"} // Choose a port
+	http.HandleFunc("/webhook/inbound", r.webhookHandler)
+
+	go func() {
+		if err := r.server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Log.Error(err, "Failed to start HTTP server")
+		}
+	}()
+
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&kubechainv1alpha1.TaskRunToolCall{}).
 		Complete(r)
+}
+
+func (r *TaskRunToolCallReconciler) Stop() {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := r.server.Shutdown(ctx); err != nil {
+		log.Log.Error(err, "Failed to shut down HTTP server")
+	}
 }

--- a/kubechain/internal/controller/tool/suite_test.go
+++ b/kubechain/internal/controller/tool/suite_test.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tool
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	kubechainv1alpha1 "github.com/humanlayer/smallchain/kubechain/api/v1alpha1"
+)
+
+var (
+	ctx       context.Context
+	cancel    context.CancelFunc
+	testEnv   *envtest.Environment
+	cfg       *rest.Config
+	k8sClient client.Client
+)
+
+func TestControllers(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Controller Suite")
+}
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+	ctx, cancel = context.WithCancel(context.TODO())
+
+	By("bootstrapping test environment")
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: true,
+		BinaryAssetsDirectory: filepath.Join("..", "..", "bin", "k8s", "1.32.0-darwin-arm64"),
+	}
+
+	var err error
+	cfg, err = testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
+
+	err = kubechainv1alpha1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(k8sClient).NotTo(BeNil())
+})
+
+var _ = AfterSuite(func() {
+	By("tearing down the test environment")
+	cancel()
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
+})

--- a/kubechain/internal/controller/tool/tool_controller.go
+++ b/kubechain/internal/controller/tool/tool_controller.go
@@ -1,4 +1,4 @@
-package controller
+package tool
 
 import (
 	"context"

--- a/kubechain/internal/controller/tool/tool_controller_test.go
+++ b/kubechain/internal/controller/tool/tool_controller_test.go
@@ -1,4 +1,4 @@
-package controller
+package tool
 
 import (
 	"context"

--- a/kubechain/internal/externalAPI/main.go
+++ b/kubechain/internal/externalAPI/main.go
@@ -1,0 +1,73 @@
+package externalapi
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kubechainv1alpha1 "github.com/humanlayer/smallchain/kubechain/api/v1alpha1"
+)
+
+// ClientFactory is a function type for creating external API clients
+type ClientFactory func(secretData map[string][]byte, apiKeyField string) (Client, error)
+
+// Registry manages external API client creation
+type Registry struct {
+	mu        sync.RWMutex
+	factories map[string]ClientFactory
+}
+
+// NewRegistry creates a new client registry
+func NewRegistry() *Registry {
+	return &Registry{
+		factories: make(map[string]ClientFactory),
+	}
+}
+
+// Register adds a new client factory to the registry
+func (r *Registry) Register(toolName string, factory ClientFactory) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.factories[toolName] = factory
+}
+
+// GetClient retrieves and instantiates a client for a specific tool
+func (r *Registry) GetClient(
+	toolName string,
+	k8sClient client.Client,
+	namespace string,
+	credentialsRef *kubechainv1alpha1.SecretKeyRef,
+) (Client, error) {
+	r.mu.RLock()
+	factory, exists := r.factories[toolName]
+	r.mu.RUnlock()
+
+	if !exists {
+		return nil, fmt.Errorf("no client factory registered for tool: %s", toolName)
+	}
+
+	// Fetch the secret
+	var secret corev1.Secret
+	if err := k8sClient.Get(context.Background(), client.ObjectKey{
+		Namespace: namespace,
+		Name:      credentialsRef.Name,
+	}, &secret); err != nil {
+		return nil, fmt.Errorf("failed to retrieve secret: %w", err)
+	}
+
+	// Use the factory to create the client
+	return factory(secret.Data, credentialsRef.Key)
+}
+
+// DefaultRegistry is a global registry for external API clients
+var DefaultRegistry = NewRegistry()
+
+// Client defines the interface for external API interactions
+type Client interface {
+	// Call executes a function call with the given parameters
+	Call(ctx context.Context, runID, callID string, spec map[string]interface{}) (json.RawMessage, error)
+}

--- a/kubechain/internal/humanlayer/client.go
+++ b/kubechain/internal/humanlayer/client.go
@@ -1,0 +1,197 @@
+package humanlayer
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"time"
+
+	externalapi "github.com/humanlayer/smallchain/kubechain/internal/externalAPI"
+)
+
+type FunctionCallStatus struct {
+	RequestedAt      *time.Time `json:"requested_at"`
+	RespondedAt      *time.Time `json:"responded_at"`
+	Approved         *bool      `json:"approved"`
+	Comment          *string    `json:"comment"`
+	RejectOptionName *string    `json:"reject_option_name"`
+}
+
+type FunctionCall struct {
+	RunID  string              `json:"run_id"`
+	CallID string              `json:"call_id"`
+	Spec   map[string]any      `json:"spec"` // Assuming spec is a map
+	Status *FunctionCallStatus `json:"status"`
+}
+
+type Approved struct {
+	Approved bool    `json:"approved"`
+	Comment  *string `json:"comment"`
+}
+
+type Rejected struct {
+	Approved bool   `json:"approved"`
+	Comment  string `json:"comment"`
+}
+
+func (fcs *FunctionCallStatus) AsCompleted() (interface{}, error) {
+	if fcs.Approved == nil {
+		return nil, fmt.Errorf("FunctionCallStatus.AsCompleted() called before approval")
+	}
+
+	if *fcs.Approved {
+		return Approved{Approved: *fcs.Approved, Comment: fcs.Comment}, nil
+	}
+
+	if !*fcs.Approved && fcs.Comment == nil {
+		return nil, fmt.Errorf("FunctionCallStatus.Rejected with no comment")
+	}
+
+	return Rejected{Approved: *fcs.Approved, Comment: *fcs.Comment}, nil
+}
+
+// Client implements the external API client for HumanLayer
+type Client struct {
+	apiKey     string
+	baseURL    string
+	httpClient *http.Client
+}
+
+// NewClient creates a new HumanLayer API client
+func NewClient(apiKey string) externalapi.Client {
+	return &Client{
+		apiKey:  apiKey,
+		baseURL: "https://api.humanlayer.dev/humanlayer/v1/function_calls",
+		httpClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+	}
+}
+
+// Call executes a function call to the HumanLayer API
+func (c *Client) Call(
+	ctx context.Context,
+	runID,
+	callID string,
+	spec map[string]interface{},
+) (json.RawMessage, error) {
+	// Debug logging
+	fmt.Printf("HumanLayer Call - runID: %s, callID: %s, spec: %+v\n", runID, callID, spec)
+
+	// Ensure kwargs is properly structured
+	if fn, ok := spec["fn"].(string); ok && fn == "approve_tool_call" {
+		if _, exists := spec["kwargs"]; !exists {
+			// If kwargs doesn't exist, create it
+			spec["kwargs"] = map[string]interface{}{}
+		}
+
+		// If kwargs is nil, recreate it
+		if spec["kwargs"] == nil {
+			spec["kwargs"] = map[string]interface{}{
+				"tool_name": "unknown", // Default values
+				"task_run":  runID,
+				"namespace": "default",
+			}
+		}
+
+		// Ensure kwargs is properly typed
+		kwargs, ok := spec["kwargs"].(map[string]interface{})
+		if !ok {
+			// Convert or recreate kwargs
+			spec["kwargs"] = map[string]interface{}{
+				"tool_name": "unknown", // Default values
+				"task_run":  runID,
+				"namespace": "default",
+			}
+		} else if len(kwargs) == 0 {
+			// If kwargs is empty, add default values
+			kwargs["tool_name"] = "unknown"
+			kwargs["task_run"] = runID
+			kwargs["namespace"] = "default"
+			spec["kwargs"] = kwargs
+		}
+	}
+
+	// Now do the API call with the fixed spec
+
+	// Prepare the request payload
+	payload := map[string]interface{}{
+		"run_id":  runID,
+		"call_id": callID,
+		"spec":    spec,
+	}
+
+	// Log final payload
+	fmt.Printf("Final API payload: %+v\n", payload)
+
+	// Convert payload to JSON
+	reqBody, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("failed to prepare request body: %w", err)
+	}
+
+	// Create HTTP request
+	req, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodPost,
+		c.baseURL,
+		bytes.NewBuffer(reqBody),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create HTTP request: %w", err)
+	}
+
+	// Set headers
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+
+	// Execute the request
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("API request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// Read response body
+	respBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	// Check for non-success status code
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("API returned non-success status: %d, body: %s",
+			resp.StatusCode, string(respBody))
+	}
+
+	// Return raw JSON response
+	return json.RawMessage(respBody), nil
+}
+
+// ClientFactory creates a HumanLayer client from secret data
+func ClientFactory(secretData map[string][]byte, apiKeyField string) (externalapi.Client, error) {
+	apiKeyBytes, exists := secretData[apiKeyField]
+	if !exists {
+		return nil, fmt.Errorf("API key not found in secret")
+	}
+
+	apiKey := string(apiKeyBytes)
+	if apiKey == "" {
+		return nil, fmt.Errorf("empty API key in secret")
+	}
+
+	return NewClient(apiKey), nil
+}
+
+// Initialize the client in an init function
+func init() {
+	externalapi.DefaultRegistry.Register("humanlayer-function-call", ClientFactory)
+}
+
+// RegisterClient adds the HumanLayer client to the external API registry
+func RegisterClient() {
+	externalapi.DefaultRegistry.Register("humanlayer-function-call", ClientFactory)
+}

--- a/kubechain/internal/humanlayer/test_client.go
+++ b/kubechain/internal/humanlayer/test_client.go
@@ -1,0 +1,40 @@
+package humanlayer
+
+import (
+	"context"
+	"fmt"
+	"log"
+)
+
+func RunTest() {
+	// Create a new client with your API key
+	client := NewClient("hl-a-xg52uTvDVR_XQohWAXvz4cFjVIVve-DfCBSELw3KCK4")
+
+	// Create a context
+	ctx := context.Background()
+
+	// Example function call
+	response, err := client.CallFunction(
+		ctx,
+		"run-123",          // Run ID
+		"call-456",         // Call ID
+		"example_function", // Function name
+		map[string]interface{}{ // Arguments
+			"param1": "value1",
+			"param2": 42,
+		},
+	)
+	if err != nil {
+		log.Fatalf("Error calling function: %v", err)
+	}
+
+	fmt.Printf("Initial response: %+v\n", response)
+
+	// Poll for approval
+	finalResponse, err := client.PollForApproval(ctx, response.CallID)
+	if err != nil {
+		log.Fatalf("Error polling for approval: %v", err)
+	}
+
+	fmt.Printf("Final response: %+v\n", finalResponse)
+}


### PR DESCRIPTION
### What I did

1. Moved controller packages into their own designated packages.
2. Added 2 tests for the taskrun controller: one to make sure TaskRun state is in `ToolCallsPending` state when its TaskRunToolCalls have not succeeded, one to make sure TaskRun state gets to `ReadyForLLM` state when its TaskRunToolCalls have succeeded.
4. Introduced humanlayer support

- extended the toolspec via ExternalAPI spec
- taskruntoolcall introduces a webhook endpoint that updates the status of the human-approval taskruntoolcall.

### How I did it

Get Go tests set up with Dex. Bought Cursor.

### Description for the CHANGELOG

1. Fixed the taskrun controller child runs to close
3. Introduced humanlayer support, and extended the toolspec via ExternalAPI spec.

### Picture of a cute animal

![Dolphin Facts](https://www.dolphinproject.com/wp-content/uploads/2020/07/Dolphin-Facts-1.jpg)
