### PR TITLE
Fix otel deploy in examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 ts/chains.db
 kubechain/config/secretskubechain/config/secrets/
+.idea/

--- a/kubechain-example/README.md
+++ b/kubechain-example/README.md
@@ -1,3 +1,60 @@
 [Makefile](./Makefile) - commands to deploy the stack - use `make otel-stack otel-test` to deploy the stack and test it
 [agents](./agents) - custom resources to deploy a simple calculator agent
 [otel](./otel) - values for the otel collector, and script to push data in
+
+
+# What is happening here?
+
+This is a demo environment for Kubechain that also deploys a complete observability stack (Prometheus, Grafana, Tempo, Loki) for monitoring LLM operations. You can use this demo to test and interact with LLM-powered agents running in a K8s cluster (behind `kind`).
+
+# Prerequisites
+
+- Docker
+- Kind (Kubernetes in Docker)
+- Helm
+- kubectl
+- uv (Python package manager)
+
+## Getting Started
+
+1. Create a local Kubernetes cluster:
+   ```
+   make kind-up
+   ```
+
+2. Deploy the complete observability stack:
+   ```
+   make otel-stack
+   ```
+
+3. Build and deploy the Kubechain operator:
+   ```
+   make operator-build operator-deploy
+   ```
+
+4. Deploy example agents:
+   ```
+   kubectl apply -f agents/crds.yaml
+   ```
+
+5. Run a test to generate telemetry data:
+   ```
+   make otel-test
+   ```
+
+6. Access the monitoring dashboards:
+   ```
+   make otel-access
+   ```
+   
+   - Grafana: http://localhost:13000 (password: admin)
+   - Prometheus: http://localhost:9090
+
+## Cleanup
+
+To tear down the environment:
+
+```
+make otel-stack-down
+make kind-down
+```

--- a/kubechain-example/loki/values.yaml
+++ b/kubechain-example/loki/values.yaml
@@ -20,9 +20,9 @@ backend:
   replicas: 0
 
 loki:
-  # Turn off structured metadata requirement with older schema
+  # Enable structured metadata for OTLP logs
   limits_config:
-    allow_structured_metadata: false
+    allow_structured_metadata: true
 
   auth_enabled: false
 

--- a/kubechain-example/otel/values.yaml
+++ b/kubechain-example/otel/values.yaml
@@ -30,8 +30,9 @@ config:
         insecure: true
     prometheus:
       endpoint: "0.0.0.0:8889"
-    loki:
-      endpoint: "http://loki:3100/loki/api/v1/push"
+    # Loki now supports OTLP natively
+    otlphttp:
+      endpoint: "http://loki:3100/otlp"
       tls:
         insecure: true
   extensions:
@@ -64,7 +65,7 @@ config:
       logs:
         receivers: [otlp]
         processors: [memory_limiter, batch]
-        exporters: [debug, loki]
+        exporters: [debug, otlphttp]
 
 extraEnvs:
   - name: MY_POD_IP


### PR DESCRIPTION
It seems like what happened is that the `loki` exporter [was deprecated](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/lokiexporter) at some point because it began supporting OTLP natively (we use the `latest` tag when running the `otlp` stack). 